### PR TITLE
Install and test with but disable `OCamlFormat`

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -6,7 +6,7 @@ S cil/
 B _build/**/*
 
 # Dependencies
-PKG extlib fileutils batteries ocamlgraph camlp4 camlp4.lib xml-light
+PKG extlib fileutils batteries ocamlgraph ocamlformat camlp4 camlp4.lib xml-light
 
 # Extra flags
 FLG -debug locate,/tmp/merlin-debug

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,5 @@
+version=0.14.2
+
+# to enable a whole directory, put "disable=false" in dir/.ocamlformat
+# to enable specific files put them in .ocamlformat-enable
+disable=true

--- a/.travis/script
+++ b/.travis/script
@@ -41,6 +41,7 @@ travis_jigger() {
 }
 
 set -ev
+find . -name _build -not -prune -or -name '*.ml' -and -not -name '*.pp.ml' -or -name '*.mli' -and -not -name '*.pp.mli' | xargs ocamlformat -i
 cd examples/working
 s=$HIPSLEEK_TESTS_START # assume is integer
 e=$HIPSLEEK_TESTS_END # assume is integer

--- a/.travis/script
+++ b/.travis/script
@@ -41,6 +41,7 @@ travis_jigger() {
 }
 
 set -ev
+eval $(opam env)
 find . -name _build -not -prune -or -name '*.ml' -and -not -name '*.pp.ml' -or -name '*.mli' -and -not -name '*.pp.mli' | xargs ocamlformat -i
 cd examples/working
 s=$HIPSLEEK_TESTS_START # assume is integer

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ OPAM_PKGS = [
   "fileutils",
   "batteries",
   "ocamlgraph",
+  "ocamlformat",
   "camlp4",
   "xml-light"
 ]
@@ -12,6 +13,7 @@ OCAMLFIND_DEPS = [
   "fileutils",
   "batteries",
   "ocamlgraph",
+  "ocamlformat",
   "camlp4",
   "camlp4.lib",
   "xml-light"

--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
-true: warn_error(+4+8+9+11+12+25+28), warn(-26), bin_annot, package(extlib), package(fileutils), package(batteries), package(ocamlgraph), package(camlp4), package(camlp4.lib), package(xml-light)
+true: warn_error(+4+8+9+11+12+25+28), warn(-26), bin_annot, package(extlib), package(fileutils), package(batteries), package(ocamlgraph), package(ocamlformat), package(camlp4), package(camlp4.lib), package(xml-light)
 <{parser,parse_fix,parse_fixbag,parse_shape,parse_cmd}.ml>: pp(camlp4of)
 not(<{parser,parse_fix,parse_fixbag,parse_shape,parse_cmd}.ml> or <cil/ocamlutil/errormsg.ml>): pp(cppo -I ../ -D TRACE)
 "joust": include


### PR DESCRIPTION
Fix #9.

The contents of `.ocamlformat` is inspired by https://github.com/coq/coq/blob/a89ea61/.ocamlformat.
1. `OCamlFormat` only runs, within selected directories, when explicitly told to run. This makes sure of two things: one: Travis CI still passes, and two: contributors don't have to worry about merging linted code, until they are ready for their code to be linted.
1. The `profile` option is unspecified, such that the `default` profile is used.

The test `find . -name _build -not -prune -or -name '*.ml' -and -not -name '*.pp.ml' -or -name '*.mli' -and -not -name '*.pp.mli' | xargs ocamlformat -i` is inspired by https://github.com/ocaml-ppx/ocamlformat/blob/4d4b0c4/test-extra/Makefile#L113.