### PR TITLE
Define String, SConst, StringLit, and associated funcs

### DIFF
--- a/cast.ml
+++ b/cast.ml
@@ -419,6 +419,10 @@ and exp_iconst = {
   exp_iconst_val : int;
   exp_iconst_pos : loc }
 
+and exp_sconst = {
+  exp_sconst_val : string;
+  exp_sconst_pos : loc }
+
 and exp_new = {
   exp_new_class_name : ident;
   exp_new_parent_name : ident;
@@ -557,6 +561,7 @@ and exp = (* expressions keep their types *)
         *)
   | ICall of exp_icall
   | IConst of exp_iconst
+  | SConst of exp_sconst
   (*| ArrayAlloc of exp_aalloc *) (* An Hoa *)
   | New of exp_new
   | Null of loc
@@ -1090,6 +1095,7 @@ let transform_exp (e:exp) (init_arg:'b)(f:'b->exp->(exp* 'a) option)  (f_args:'b
       | FConst _
       | ICall _
       | IConst _
+      | SConst _
       (* | ArrayAlloc _ *) (* An Hoa *)
       | New _
       | Null _
@@ -1216,6 +1222,8 @@ let void_type = Void
 
 let int_type = Int
 
+let string_type = String
+
 let infint_type = INFInt
 
 let float_type = Float
@@ -1305,6 +1313,7 @@ let rec type_of_exp (e : exp) = match e with
   (*| FieldRead (t, _, _, _) -> Some t*)
   (*| FieldWrite _ -> Some Void*)
   | IConst _ -> Some int_type
+  | SConst _ -> Some string_type
   (* An Hoa *)
   (* | ArrayAlloc ({exp_aalloc_etype = t;
      		  exp_aalloc_dimension = _;
@@ -2162,6 +2171,7 @@ and callees_of_exp (e0 : exp) : ident list = match e0 with
             exp_icall_arguments = _;
             exp_icall_pos = _}) -> [unmingle_name n] (* to be fixed: look up n, go down recursively *)
   | IConst _ -> []
+  | SConst _ -> []
   (*| ArrayAlloc _ -> []*)
   | New _ -> []
   | Null _ -> []
@@ -2432,6 +2442,7 @@ and exp_to_check (e:exp) :bool = match e with
   | Assign _
   | ICall _
   | IConst _
+  | SConst _
   | While _
   | This _
   | Var _
@@ -2459,6 +2470,7 @@ let rec pos_of_exp (e:exp) :loc = match e with
   | FConst b -> b.exp_fconst_pos
   | ICall b -> b.exp_icall_pos
   | IConst b -> b.exp_iconst_pos
+  | SConst b -> b.exp_sconst_pos
   | Print (_,b) -> b
   | Seq b -> b.exp_seq_pos
   | VarDecl b -> b.exp_var_decl_pos
@@ -2996,6 +3008,7 @@ let exp_fv (e:exp) =
     | FConst _ -> Some ac
     | ICall b -> Some (b.exp_icall_receiver::b.exp_icall_arguments@ac)
     | IConst _ -> Some ac
+    | SConst _ -> Some ac
     | New b -> Some ((List.map snd b.exp_new_arguments)@ac)
     | Null _ -> Some ac
     | EmptyArray _ -> Some ac

--- a/cformula.ml
+++ b/cformula.ml
@@ -18587,6 +18587,7 @@ let elim_prm e =
   let f_e e = match e with
     | CP.Null _
     | CP.IConst _
+    | CP.SConst _
     | CP.AConst _
     | CP.Tsconst _
     | CP.FConst _

--- a/cilparser.ml
+++ b/cilparser.ml
@@ -155,6 +155,7 @@ let rec loc_of_iast_exp (e: Iast.exp) : VarGen.loc =
   | Iast.FloatLit e -> e.Iast.exp_float_lit_pos
   | Iast.Finally e -> e.Iast.exp_finally_pos
   | Iast.IntLit e -> e.Iast.exp_int_lit_pos
+  | Iast.StringLit e -> e.Iast.exp_string_lit_pos
   | Iast.Java e -> e.Iast.exp_java_pos
   | Iast.Label (_, e1) -> loc_of_iast_exp e1
   | Iast.Member e -> e.Iast.exp_member_pos
@@ -1389,7 +1390,7 @@ and translate_constant (c: Cil.constant) (lopt: Cil.location option) : Iast.exp 
   let pos = match lopt with None -> no_pos | Some l -> translate_location l in
   match c with
   | Cil.CInt64 (i, _, _) -> Iast.mkIntLit (Int64.to_int i) pos
-  | Cil.CStr s -> report_error pos "TRUNG TODO: Handle Cil.CStr later!"
+  | Cil.CStr s -> Iast.mkStringLit s pos
   | Cil.CWStr _ -> report_error pos "TRUNG TODO: Handle Cil.CWStr later!"
   (*| Cil.CChr _ -> report_error pos "TRUNG TODO: Handle Cil.CChr later!"*)
   | Cil.CChr c -> Iast.mkIntLit (Char.code c) pos
@@ -2290,6 +2291,8 @@ and translate_hip_exp_x (exp: Iast.exp) pos : Iast.exp =
       Iast.mkMember addr_var ["deref"] None pos*)
     | Ipure.IConst (i, pos) ->
       Ipure.IConst (i, pos)
+    | Ipure.SConst (s, pos) ->
+      Ipure.SConst (s, pos)
     | Ipure.FConst (f, pos) ->
       Ipure.FConst (f, pos)
     | Ipure.AConst (ha, pos) ->

--- a/cilparser.ml
+++ b/cilparser.ml
@@ -1286,7 +1286,7 @@ and translate_typ_x (t: Cil.typ) pos : Globals.typ =
     match t with
     | Cil.TVoid _ -> Globals.Void
     | Cil.TInt (Cil.IBool, _) -> Globals.Bool
-    (*| Cil.TInt (Cil.IChar, _) -> Globals.Named "char"*)
+    | Cil.TInt (Cil.IChar, _) -> Globals.Named "char"
     | Cil.TInt _ -> Globals.Int
     | Cil.TFloat _ -> Globals.Float
     | Cil.TPtr (ty, _) -> (

--- a/coq.ml
+++ b/coq.ml
@@ -29,6 +29,7 @@ let rec coq_of_typ = function
   | Bool          -> "int"
   | Float         -> "float"	(* all types will be ints. *)
   | Int | INFInt  -> "int"
+  | String -> illegal_format ("coq_of_typ: String type not supported for Coq")
   | AnnT          -> "int"
   | Void          -> "unit" 	(* all types will be ints. *)
   | BagT t		   -> "("^(coq_of_typ t) ^") set"
@@ -85,6 +86,7 @@ and coq_of_exp e0 =
   | CP.Null _ -> "0"
   | CP.Var (sv, _) -> coq_of_spec_var sv
   | CP.IConst (i, _) -> string_of_int i
+  | CP.SConst (s, _) -> failwith ("coq_of_exp: String cannot be handled")
   | CP.Tsconst _ -> failwith ("tsconst not supported in coq, should have already been handled")
   | CP.Bptriple _ | CP.Tup2 _ ->  illegal_format "coq_of_exp : bptriple/Tup2 cannot be handled"
   | CP.AConst (i, _) -> string_of_heap_ann i

--- a/cprinter.ml
+++ b/cprinter.ml
@@ -862,6 +862,7 @@ let rec pr_formula_exp (e:P.exp) =
   | P.Var (x, l) -> fmt_string (string_of_spec_var x) (* fmt_string (string_of_typed_spec_var x) *)
   | P.Level (x, l) -> fmt_string ("level(" ^ (string_of_spec_var x) ^ ")")
   | P.IConst (i, l) -> fmt_int i
+  | P.SConst (s, l) -> fmt_string s
   | P.AConst (i, l) -> fmt_string (string_of_heap_ann i)
   | P.InfConst (i,l) -> let r = "\\inf" in fmt_string r
   | P.NegInfConst (i,l) -> let r = "~\\inf" in fmt_string r
@@ -4726,6 +4727,7 @@ let rec string_of_exp = function
   (*| FieldRead (_, (v, _), (f, _), _) -> v ^ "." ^ f*)
   (*| FieldWrite ((v, _), (f, _), r, _) -> v ^ "." ^ f ^ " = " ^ r*)
   | IConst ({exp_iconst_val = i; exp_iconst_pos = l}) -> string_of_int i
+  | SConst ({exp_sconst_val = s; exp_sconst_pos = l}) -> s
   | New ({exp_new_class_name = id;
           exp_new_arguments = idl;
           exp_new_pos = l}) ->
@@ -5248,6 +5250,7 @@ let rec html_of_formula_exp e =
   | P.Var (x, l) -> html_of_spec_var x
   | P.Level (x, l) -> "<level>" ^ html_of_spec_var x ^ "</level>"
   | P.IConst (i, l) -> string_of_int i
+  | P.SConst (s, l) -> s
   | P.FConst (f, l) -> string_of_float f
   | P.AConst (f, l) -> string_of_heap_ann f
   | P.Tsconst(f, l) -> Tree_shares.Ts.string_of f

--- a/cvc3.ml
+++ b/cvc3.ml
@@ -61,6 +61,7 @@ and cvc3_of_exp a = match a with
   | CP.Null _ -> "0"
   | CP.Var (sv, _) -> cvc3_of_spec_var sv
   | CP.IConst (i, _) -> string_of_int i
+  | CP.SConst (s, _) -> failwith ("cvc3_of_exp: String cannot be handled")
   | CP.FConst _ -> failwith ("[cvc3ite.ml]: ERROR in constraints (float should not appear here)")
   | CP.Add (a1, a2, _) ->  (cvc3_of_exp a1) ^ " + " ^ (cvc3_of_exp a2)
   | CP.Subtract (a1, a2, _) ->  (cvc3_of_exp a1) ^ " - " ^ (cvc3_of_exp a2)

--- a/cvclite.ml
+++ b/cvclite.ml
@@ -97,6 +97,7 @@ and cvcl_of_exp a = match a with
   | CP.Null _ -> "0"
   | CP.Var (sv, _) -> cvcl_of_spec_var sv
   | CP.IConst (i, _) -> string_of_int i
+  | CP.SConst (s, _) -> failwith ("cvclite.cvcl_of_exp: String cannot be handled")
   | CP.FConst _ -> failwith ("[cvclite.ml]: ERROR in constraints (float should not appear here)")
   | CP.Add (a1, a2, _) ->  (cvcl_of_exp a1) ^ " + " ^ (cvcl_of_exp a2)
   | CP.Subtract (a1, a2, _) ->  (cvcl_of_exp a1) ^ " - " ^ (cvcl_of_exp a2)

--- a/da.ml
+++ b/da.ml
@@ -114,7 +114,7 @@ let case_analysis_x proc targs (e0:exp) ctx_p :sympath list =
     | CheckRef _ | BConst _
     | Debug _    | Dprint _
     | FConst _   | ICall _
-    | IConst _   | New _
+    | IConst _   | SConst _ | New _
     | Null _  | EmptyArray _ (* An Hoa *)
     | Print _ | Barrier _
     | This _   | Time _
@@ -296,7 +296,7 @@ let find_rel_args_groups_x prog proc e0=
     | CheckRef _ | BConst _
     | Debug _    | Dprint _
     | FConst _   | ICall _
-    | IConst _   | New _
+    | IConst _   | SConst _ | New _
     | Null _  | EmptyArray _ (* An Hoa *)
     | Print _ | Barrier _
     | This _   | Time _

--- a/exc.ml
+++ b/exc.ml
@@ -832,6 +832,7 @@ struct
     | BagT et1, BagT et2 -> sub_type et1 et2
     | List et1, List et2 -> sub_type et1 et2
     | Int, NUM        -> true
+    | String, Named "char_star" -> true
     | Float, NUM        -> true
     | p1, p2 -> p1=p2
   ;;

--- a/globals.ml
+++ b/globals.ml
@@ -192,6 +192,7 @@ type typ =
   | TVar of int
   | AnnT
   | Bool
+  | String
   | Float
   | Int
   | INFInt
@@ -298,6 +299,7 @@ let rec cmp_typ t1 t2=
   | UNK, UNK
   | AnnT, AnnT
   | Bool, Bool
+  | String, String
   | Float, Float
   | Int, Int
   | INFInt, INFInt
@@ -609,6 +611,7 @@ let rec string_of_typ (x:typ) : string = match x with
   | FORM          -> "Formula"
   | UNK          -> "Unknown"
   | Bool          -> "boolean"
+  | String          -> "string"
   | Float         -> "float"
   | Int           -> "int"
   | INFInt        -> "INFint"
@@ -663,6 +666,7 @@ let rec string_of_typ_alpha = function
   | FORM          -> "Formula"
   | UNK          -> "Unknown"
   | Bool          -> "boolean"
+  | String          -> "string"
   | Float         -> "float"
   | Int           -> "int"
   | INFInt        -> "INFint"

--- a/globalvars.ml
+++ b/globalvars.ml
@@ -211,6 +211,7 @@ let rec find_read_write_global_var
     | I.Empty _ 
     | I.FloatLit _ 
     | I.IntLit _ 
+    | I.StringLit _ 
     | I.Java _
     | I.Null _ 
     | I.This _ 
@@ -705,6 +706,7 @@ and extend_body (temp_procs : I.proc_decl list) (exp : I.exp) : I.exp =
   | I.Empty _
   | I.FloatLit _
   | I.IntLit _
+  | I.StringLit _
   | I.Java _
   | I.Null _
   | I.This _
@@ -925,6 +927,7 @@ let rec check_and_change (global_vars : IdentSet.t) (exp : I.exp) : I.exp =
   | I.Empty _
   | I.FloatLit _
   | I.IntLit _
+  | I.StringLit _
   | I.Java _
   | I.Null _
   | I.This _

--- a/iast.ml
+++ b/iast.ml
@@ -409,6 +409,9 @@ and exp_block = { exp_block_body : exp;
 and exp_bool_lit = { exp_bool_lit_val : bool;
                      exp_bool_lit_pos : loc }
 
+and exp_string_lit = { exp_string_lit_val : string;
+                       exp_string_lit_pos : loc }
+
 and exp_barrier = {exp_barrier_recv : ident; exp_barrier_pos : loc}
 
 (* WN : why do we have two kinds of calls? should unify *)
@@ -576,6 +579,7 @@ and exp =
   | FloatLit of exp_float_lit
   | Finally of exp_finally
   | IntLit of exp_int_lit
+  | StringLit of exp_string_lit
   | Java of exp_java
   | Label of ((control_path_id * path_label) * exp)
   | Member of exp_member
@@ -599,6 +603,8 @@ and exp =
 let void_type = Void
 
 let int_type = Int
+
+let string_type = Globals.String
 
 let infint_type = INFInt
 
@@ -847,6 +853,7 @@ let trans_exp (e:exp) (init_arg:'b) (f:'b->exp->(exp* 'a) option)  (f_args:'b->e
       | Empty _
       | FloatLit _
       | IntLit _
+      | StringLit _
       | Java _
       | Null _
       | This _
@@ -1001,6 +1008,7 @@ let fold_exp (e:exp) (init_arg:'b) (f:'b->exp-> 'a option)  (f_args:'b->exp->'b)
       | Empty _
       | FloatLit _
       | IntLit _
+      | StringLit _
       | Java _
       | Null _
       | This _
@@ -1175,6 +1183,10 @@ let is_num (e : exp) : bool = match e with
   | FloatLit _ | IntLit _ -> true
   | _ -> false
 
+let is_string (e : exp) : bool = match e with
+  | StringLit _ -> true
+  | _ -> false
+
 let is_mult_op b =
   match b with | OpMult -> true | _ -> false
 
@@ -1213,6 +1225,7 @@ let rec get_exp_pos (e0 : exp) : loc = match e0 with
   | FloatLit e -> e.exp_float_lit_pos
   | Finally e -> e.exp_finally_pos
   | IntLit e -> e.exp_int_lit_pos
+  | StringLit e -> e.exp_string_lit_pos
   | Java e -> e.exp_java_pos
   | Member e -> e.exp_member_pos
   | ArrayAlloc e -> e.exp_aalloc_pos (* An Hoa *)
@@ -2616,6 +2629,10 @@ and mkIntLit i pos =
   IntLit { exp_int_lit_val = i;
            exp_int_lit_pos = pos }
 
+and mkStringLit s pos =
+  StringLit { exp_string_lit_val = s;
+              exp_string_lit_pos = pos; }
+
 and mkFloatLit f pos =
   FloatLit { exp_float_lit_val = f;
              exp_float_lit_pos = pos}
@@ -2804,6 +2821,7 @@ let rec label_e e =
     | Empty _
     | FloatLit _
     | IntLit _
+    | StringLit _
     | Java _
     | Unfold _
     | Var _
@@ -3825,6 +3843,7 @@ let find_all_num_trailer_exp e =
     | CallRecv b -> Some ac
     | CallNRecv b -> Some ac
     | IntLit _ -> Some ac
+    | StringLit _ -> Some ac
     | New b -> Some ac
     | Null _ -> Some ac
     | Empty _ -> Some ac

--- a/iastUtil.ml
+++ b/iastUtil.ml
@@ -36,6 +36,7 @@ let transform_exp
       | Empty _ 
       | FloatLit _ 
       | IntLit _
+      | StringLit _
       | Java _ 
       | Null _ 
       | This _ 

--- a/infinity.ml
+++ b/infinity.ml
@@ -874,6 +874,7 @@ let rec sub_inf_list_exp (exp: CP.exp) (vars: CP.spec_var list) (is_neg: bool) :
   match exp with
   | CP.Null _
   | CP.IConst _
+  | CP.SConst _
   | CP.AConst _ 
   | CP.InfConst _
   | CP.NegInfConst _

--- a/iprinter.ml
+++ b/iprinter.ml
@@ -200,6 +200,7 @@ let rec string_of_formula_exp = function
   | P.Var (x, l)        -> string_of_id x
   | P.Level (x, l)        -> ("level(" ^ (string_of_id x) ^ ")")
   | P.IConst (i, l)           -> string_of_int i
+  | P.SConst (s, l)           -> s
   | P.InfConst(s,l) -> s
   | P.NegInfConst(s,l) -> "~"^s
   | P.AConst (i, l)           -> string_of_heap_ann i
@@ -828,6 +829,7 @@ let rec string_of_exp = function
   | BoolLit ({exp_bool_lit_val = b})
       -> string_of_bool b 
   | IntLit ({exp_int_lit_val = i}) -> string_of_int i
+  | StringLit ({exp_string_lit_val = s}) -> s
   | FloatLit ({exp_float_lit_val = f})
       -> string_of_float f
   | Null l                         -> "null"

--- a/ipure.ml
+++ b/ipure.ml
@@ -245,6 +245,7 @@ and afv (af : exp) : (ident * primed) list = match af with
   | Null _ 
   | AConst _ 
   | IConst _ 
+  | SConst _ 
   | Tsconst _ 
   | InfConst _
   | NegInfConst _
@@ -308,6 +309,11 @@ and is_integer e =
   | Add (e1, e2, _) | Subtract (e1, e2, _) | Mult (e1, e2, _)
   | Max (e1, e2, _) | Min (e1, e2, _) ->
     is_integer e1 && is_integer e2
+  | _ -> false
+
+and is_string e =
+  match e with
+  | SConst _ -> true
   | _ -> false
 
 and is_list (e : exp) : bool = match e with
@@ -606,6 +612,7 @@ and pos_of_exp (e : exp) = match e with
   | Var (_, p) 
   | Level (_, p) 
   | IConst (_, p) 
+  | SConst (_, p) 
   | FConst (_, p) 
   | Tsconst (_, p)
   | Bptriple (_, p)
@@ -838,6 +845,7 @@ and subst_exp sst (e: exp) : exp =
 and e_apply_one ((fr, t) as p) e = match e with
   | Null _ 
   | IConst _ 
+  | SConst _ 
   | FConst _ 
   | Tsconst _
   | InfConst _
@@ -1053,6 +1061,7 @@ and find_lexp_exp (e: exp) ls =
     | Var _
     | Level _
     | IConst _
+    | SConst _
     | AConst _
     | Tsconst _
     | InfConst _
@@ -1124,6 +1133,7 @@ let rec contain_vars_exp (expr : exp) : bool =
   | Var _ 
   | Level _ 
   | IConst _ 
+  | SConst _ 
   | AConst _ 
   | Tsconst _
   | Bptriple _ (* TOCHECK *)
@@ -1200,6 +1210,7 @@ and float_out_exp_min_max (e: exp): (exp * (formula * (string list) ) option) = 
   | Var _ 
   | Level _ 
   | IConst _ 
+  | SConst _ 
   | AConst _ 
   | Tsconst _
   | InfConst _ 
@@ -1602,6 +1613,7 @@ and float_out_pure_min_max (p : formula) : formula =
         | Min(v1, v2, v3) -> let r2 = match e2 with
           | Null _
           | IConst _
+          | SConst _
           | FConst _
           | AConst _
           | Tsconst _
@@ -1618,6 +1630,7 @@ and float_out_pure_min_max (p : formula) : formula =
         | Max(v1, v2, v3) -> let r2 = match e2 with
           | Null _
           | IConst _
+          | SConst _
           | AConst _
           | Tsconst _
           | Var _ ->
@@ -1633,6 +1646,7 @@ and float_out_pure_min_max (p : formula) : formula =
           in r2
         | Null _
         | IConst _
+        | SConst _
         | FConst _
         | AConst _
         | Tsconst _
@@ -1840,6 +1854,7 @@ let rec typ_of_exp (e: exp) : typ =
   (* Const *)
   | Level _                   -> Globals.level_data_typ
   | IConst _                  -> Globals.Int
+  | SConst _                  -> Globals.String
   | FConst _                  -> Globals.Float
   | InfConst _                  -> Globals.Int (* Type of Infinity should be Num keep Int for now *)
   | NegInfConst _               -> Globals.INFInt (* Type of Infinity should be Num keep Int for now *)
@@ -2069,7 +2084,7 @@ let rec transform_exp_x f (e : exp) : exp =
   match r with
   | Some ne -> ne
   | None -> (match e with
-      | Null _  | Var _ | Level _ | IConst _ | AConst _ 
+      | Null _  | Var _ | Level _ | IConst _ | SConst _ | AConst _ 
       | Tsconst _ | Bptriple _ | FConst _ | Tup2 _ -> e
       | Ann_Exp (e,t,l) ->
         let ne = transform_exp f e in

--- a/ipure_D.ml
+++ b/ipure_D.ml
@@ -123,6 +123,7 @@ and exp =
   | Var of ((ident * primed) * loc)
   (* variables could be of type pointer, int, bags, lists etc *)
   | IConst of (int * loc)
+  | SConst of (string * loc)
   | FConst of (float * loc)
   | AConst of (heap_ann * loc)
   | InfConst of (ident * loc) (* Constant for Infinity  *)

--- a/isabelle.ml
+++ b/isabelle.ml
@@ -34,6 +34,9 @@ let rec isabelle_of_typ = function
   | Tree_sh 	  -> "int"
   | Float         -> "int"	(* Can I really receive float? What do I do then? I don't have float in Isabelle.*)
   | Int           -> "int"
+  | String        ->
+    Error.report_error {Error.error_loc = no_pos; 
+                        Error.error_text = "String not supported for Isabelle"}
   | Void          -> "void" 	(* same as for float *)
   | BagT	t	  ->
     if !bag_flag then "("^(isabelle_of_typ t) ^") multiset"
@@ -117,6 +120,7 @@ let rec isabelle_of_exp e0 = match e0 with
   | CP.Null _ -> "(0::int)"
   | CP.Var (sv, _) -> isabelle_of_spec_var sv
   | CP.IConst (i, _) -> "(" ^ string_of_int i ^ "::int)"
+  | CP.SConst (s, _) -> failwith ("[isabelle.ml]: ERROR in constraints (String should not appear here)")
   | CP.FConst _ -> failwith ("[isabelle.ml]: ERROR in constraints (float should not appear here)")
   | CP.Tsconst _ -> failwith ("[isabelle.ml]: ERROR in constraints (tsconst should not appear here)")
   | CP.Bptriple _ -> failwith ("[isabelle.ml]: ERROR in constraints (Bptriple should not appear here)")

--- a/java.ml
+++ b/java.ml
@@ -338,6 +338,7 @@ and java_of_exp = function
   | BoolLit ({exp_bool_lit_val = b})
     -> string_of_bool b 
   | IntLit ({exp_int_lit_val = i}) -> string_of_int i
+  | StringLit b -> "translator is in need of reviews"
   | FloatLit ({exp_float_lit_val = f})
     -> string_of_float f
   | Null l                         -> "null"

--- a/mathematica.ml
+++ b/mathematica.ml
@@ -288,6 +288,7 @@ let rec math_of_exp e0 : string=
   | CP.Bptriple _ -> failwith ("mathematica.math_of_exp: Bptriple can't appear here")
   | CP.Tup2 _ -> failwith ("mathematica.math_of_exp: Tup2 can't appear here")
   | CP.IConst (i, _) -> string_of_int i
+  | CP.SConst (s, _) -> failwith ("mathematica.math_of_exp: String cannot be handled")
   | CP.AConst (i, _) -> string_of_int (int_of_heap_ann i)
   | CP.FConst (f, _) -> math_of_float f
   | CP.Tsconst _ -> failwith ("mathematica.math_of_exp: Tsconst can't appear here")

--- a/minisat.ml
+++ b/minisat.ml
@@ -385,6 +385,7 @@ let rec can_minisat_handle_expression (exp: Cpure.exp) : bool =
   | Cpure.Null _         -> false
   | Cpure.Var _          -> false
   | Cpure.IConst _       -> false
+  | Cpure.SConst _       -> false
   | Cpure.FConst _       -> false
   | Cpure.AConst _       -> false
   | Cpure.NegInfConst _ 

--- a/mona.ml
+++ b/mona.ml
@@ -54,6 +54,9 @@ let rec mona_of_typ t = match t with
     Error.report_error {Error.error_loc = no_pos; 
                         Error.error_text = "float type not supported for mona"}
   | Int           -> "int"
+  | String        ->
+    Error.report_error {Error.error_loc = no_pos; 
+                        Error.error_text = ("unexpected type for mona: "^(string_of_typ t))}
   | INFInt        -> "int"
   | AnnT          -> "AnnT"
   | RelT _        -> "RelT"

--- a/pointers.ml
+++ b/pointers.ml
@@ -75,6 +75,8 @@ let default_value (t :typ) pos : exp =
   match t with
   | Int -> 
     IntLit { exp_int_lit_val = 0; exp_int_lit_pos = pos; }
+  | String -> 
+    StringLit { exp_string_lit_val = ""; exp_string_lit_pos = pos; }
   | Bool ->
     BoolLit {exp_bool_lit_val = true;  exp_bool_lit_pos = pos;}
   | Float ->
@@ -329,6 +331,7 @@ let modifies (e:exp) (bvars:ident list) prog : (ident list) * (ident list) * (id
     | Empty _
     | FloatLit _
     | IntLit _
+    | StringLit _
     | Java _
     | Null _
     | Time _
@@ -528,6 +531,7 @@ let subst_exp_x (e:exp) (subst:(ident*ident) list): exp =
     | Empty _
     | FloatLit _
     | IntLit _
+    | StringLit _
     | Java _
     | Null _
     | Time _
@@ -785,6 +789,7 @@ let trans_exp_ptr_x prog (e:exp) (vars: ident list) : exp * (ident list) =
     | Empty _
     | FloatLit _
     | IntLit _
+    | StringLit _
     | Java _
     | Null _
     | Time _
@@ -1607,6 +1612,7 @@ and trans_exp_addr prog (e:exp) (vars: ident list) : exp =
     | Empty _
     | FloatLit _
     | IntLit _
+    | StringLit _
     | Java _
     | Null _
     | Time _
@@ -1744,6 +1750,7 @@ and find_addr (e:exp) : ident list =
     | Empty _
     | FloatLit _
     | IntLit _
+    | StringLit _
     | Java _
     | Null _
     | Time _
@@ -2343,6 +2350,7 @@ and find_addr_inter_exp prog proc e (vs:ident list) : ident list =
     | Empty _
     | FloatLit _
     | IntLit _
+    | StringLit _
     | Java _
     | Null _
     | Time _

--- a/predcomp.ml
+++ b/predcomp.ml
@@ -114,6 +114,9 @@ and aug_class_name (t : typ) = match t with
   | Pointer _ -> "Pointer"
   | Named c -> c ^ "Aug"
   | Int -> "IntAug"
+  | String -> 	
+    Error.report_error {Error.error_loc = no_pos; 
+                        Error.error_text = "unexpected String type"}
   | INFInt -> "INFIntAug"
   | AnnT -> "AnnAug"
   | RelT _ -> "RelAug"

--- a/rev_ast.ml
+++ b/rev_ast.ml
@@ -40,6 +40,7 @@ let rec rev_trans_exp e = match e with
     IP.Bptriple ((nc,nt,na),p)
   | CP.Tup2 ((e1,e2),p)      -> IP.Tup2 ((rev_trans_exp e1, rev_trans_exp e2), p)
   | CP.IConst b -> IP.IConst b
+  | CP.SConst b -> IP.SConst b
   | CP.FConst b -> IP.FConst b
   | CP.AConst b -> IP.AConst b
   | CP.Tsconst b -> IP.Tsconst b

--- a/setmona.ml
+++ b/setmona.ml
@@ -244,7 +244,7 @@ and to_fo (svs : spec_var list) var_map : bool =
 *)
 and compute_fo_exp (e0 : exp) order var_map : bool = match e0 with
   | Null _ 
-  | IConst _ | AConst _ -> false
+  | IConst _ | SConst _ | AConst _ -> false
   | FConst _ -> failwith ("[setmona.ml]: ERROR in constraints (float should not appear here)")
   | Tsconst _ -> failwith ("[setmona.ml]: ERROR in constraints (tsconst should not appear here)")
   | Bptriple _ -> failwith ("[setmona.ml]: ERROR in constraints (Bptriple should not appear here)")

--- a/smtsolver.ml
+++ b/smtsolver.ml
@@ -90,6 +90,7 @@ let rec smt_of_typ t =
   | TVar _ -> "Int"
   | Void -> "Int"
   | List _ -> illegal_format ("z3.smt_of_typ: "^(string_of_typ t)^" not supported for SMT")
+  | Named "char" -> "String" (* char pointers are strings *)
   | Named _ -> "Int" (* objects and records are just pointers *)
   | Array (et, d) -> compute (fun x -> "(Array Int " ^ x  ^ ")") d (smt_of_typ et)
   | FuncT (t1, t2) -> "(" ^ (smt_of_typ t1) ^ ") " ^ (smt_of_typ t2) 
@@ -121,8 +122,10 @@ let rec smt_of_exp a =
   | CP.Null _ -> "0"
   | CP.Var (sv, _) -> smt_of_spec_var sv
   | CP.Level _ -> illegal_format ("z3.smt_of_exp: level should not appear here")
-  | CP.IConst (i, _) -> if i >= 0 then string_of_int i else "(- 0 " ^ (string_of_int (0-i)) ^ ")"
-  | CP.SConst (s, _) -> "\"" ^ s ^ "\""
+  (* | CP.IConst (i, _) -> if i >= 0 then string_of_int i else "(- 0 " ^ (string_of_int (0-i)) ^ ")" *)
+  | CP.IConst (i, _) -> let () = print_string ("z3.smt_of_exp debug: " ^ str) in if i >= 0 then string_of_int i else "(- 0 " ^ (string_of_int (0-i)) ^ ")"
+  (* | CP.SConst (s, _) -> "\"" ^ s ^ "\"" *)
+  | CP.SConst (s, _) -> let () = print_string ("z3.smt_of_exp debug: " ^ str) in "\"" ^ s ^ "\""
   | CP.AConst (i, _) -> string_of_int(int_of_heap_ann i)  (*string_of_heap_ann i*)
   | CP.FConst (f, _) -> string_of_float f 
   | CP.Add (a1, a2, _) -> "(+ " ^(smt_of_exp a1)^ " " ^ (smt_of_exp a2)^")"

--- a/smtsolver.ml
+++ b/smtsolver.ml
@@ -81,6 +81,7 @@ let rec smt_of_typ t =
   | Float -> "Real" (* Currently, do not support real arithmetic! *)
   | Tree_sh -> "Int"
   | Int -> "Int"
+  | String -> "String"
   | AnnT -> "Int"
   | UNK ->  "Int" (* illegal_format "z3.smt_of_typ: unexpected UNKNOWN type" *)
   | NUM -> "Int" (* Use default Int for NUM *)
@@ -121,6 +122,7 @@ let rec smt_of_exp a =
   | CP.Var (sv, _) -> smt_of_spec_var sv
   | CP.Level _ -> illegal_format ("z3.smt_of_exp: level should not appear here")
   | CP.IConst (i, _) -> if i >= 0 then string_of_int i else "(- 0 " ^ (string_of_int (0-i)) ^ ")"
+  | CP.SConst (s, _) -> "\"" ^ s ^ "\""
   | CP.AConst (i, _) -> string_of_int(int_of_heap_ann i)  (*string_of_heap_ann i*)
   | CP.FConst (f, _) -> string_of_float f 
   | CP.Add (a1, a2, _) -> "(+ " ^(smt_of_exp a1)^ " " ^ (smt_of_exp a2)^")"

--- a/solver.ml
+++ b/solver.ml
@@ -11752,7 +11752,7 @@ and inst_before_fold_x estate rhs_p case_vars =
       let v_l = l_inter@r_inter in
       let cond =
         let rec prop_e e = match e with
-          | CP.Null _ | CP.Var _ | CP.IConst _ | CP.FConst _ | CP.AConst _ | CP.Tsconst _ | CP.InfConst _ | CP.NegInfConst _
+          | CP.Null _ | CP.Var _ | CP.IConst _ | CP.SConst _ | CP.FConst _ | CP.AConst _ | CP.Tsconst _ | CP.InfConst _ | CP.NegInfConst _
           | CP.Bptriple _ (*TOCHECK*)
           | CP.Level _ (*TOCHECK*) -> true
           | CP.Subtract (e1,e2,_) | CP.Mult (e1,e2,_) | CP.Div (e1,e2,_) | CP.Add (e1,e2,_) | CP.Tup2 ((e1,e2),_) -> prop_e e1 && prop_e e2

--- a/spass.ml
+++ b/spass.ml
@@ -44,6 +44,7 @@ let rec spass_dfg_of_exp (e0 : Cpure.exp) : (string * string list * string list)
   | Cpure.Var (sv, _) -> let func = spass_dfg_of_spec_var sv in (func, [func], [])
   (* illegal_format "SPASS don't support Var expresion" *)
   | Cpure.IConst _    -> illegal_format "SPASS don't support IConst expresion"
+  | Cpure.SConst _    -> illegal_format "SPASS don't support IConst expresion"
   | Cpure.FConst _    -> illegal_format "SPASS don't support FConst expresion"
   | Cpure.AConst _    -> illegal_format "SPASS don't support AConst expresion"
   | Cpure.Tsconst _   -> illegal_format "SPASS don't support Tsconst expresion"
@@ -193,6 +194,7 @@ let rec spass_tptp_of_exp (e0 : Cpure.exp) : string =
   | Cpure.Null _      -> "ssNULL"
   | Cpure.Var (sv, _) -> spass_tptp_of_spec_var sv
   | Cpure.IConst _    -> illegal_format "SPASS don't support IConst expresion"
+  | Cpure.SConst _    -> illegal_format "SPASS don't support SConst expresion"
   | Cpure.FConst _    -> illegal_format "SPASS don't support FConst expresion"
   | Cpure.AConst _    -> illegal_format "SPASS don't support AConst expresion"
   | Cpure.Tsconst _   -> illegal_format "SPASS don't support Tsconst expresion"
@@ -282,6 +284,7 @@ let rec can_spass_handle_expression (exp: Cpure.exp) : bool =
   | Cpure.Null _         -> true
   | Cpure.Var _          -> true
   | Cpure.IConst _       -> false
+  | Cpure.SConst _       -> false
   | Cpure.FConst _       -> false
   | Cpure.AConst _       -> false
   | Cpure.Tsconst _      -> false

--- a/testcases/ex5c-char2int.c
+++ b/testcases/ex5c-char2int.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-int* __cast_char_star_to_int_star__(char p[])
+int* __cast_char_star_to_int_star__(char *p)
 /*@
   case{
   p != null -> requires p::char_star<_,_>
@@ -21,7 +21,7 @@ int main(void)
   /*
    * big-endian integer interpretation of "type" 116 121 112 101, is 1954115685
    */
-  char s[] = {'e','p','y','t'}; // integer is little-endian
+  char *s = "eypt"; // integer is little-endian
   a = (int *)s;
   //printf("%d\n", *a);
 }

--- a/tpdispatcher.ml
+++ b/tpdispatcher.ml
@@ -735,7 +735,7 @@ let rec is_array_exp e = match e with
   | CP.Template _ -> Some false
   | CP.Func _ -> Some false
   | CP.TypeCast (_, e1, _) -> is_array_exp e1
-  | CP.AConst _ | CP.FConst _ | CP.IConst _ | CP.Tsconst _ | CP.InfConst _ 
+  | CP.AConst _ | CP.FConst _ | CP.IConst _ | CP.SConst _ | CP.Tsconst _ | CP.InfConst _ 
   | CP.NegInfConst _
   | CP.Bptriple _
   | CP.Tup2 _
@@ -775,7 +775,7 @@ let rec is_list_exp e = match e with
   | CP.Bptriple _
   | CP.Tup2 _
   | CP.Level _
-  | CP.FConst _ | CP.IConst _ -> Some false
+  | CP.FConst _ | CP.IConst _ | CP.SConst _ -> Some false
   | CP.Var(sv,_) -> if CP.is_list_var sv then Some true else Some false
 
 (*let f_e e = Debug.no_1 "f_e" (Cprinter.string_of_formula_exp) (fun s -> match s with

--- a/typechecker.ml
+++ b/typechecker.ml
@@ -2299,6 +2299,21 @@ and check_exp_a (prog : prog_decl) (proc : proc_decl) (ctx : CF.list_failesc_con
       let res_ctx = CF.normalize_max_renaming_list_failesc_context f pos true ctx in
       Gen.Profiling.pop_time "[check_exp] IConst";
       res_ctx
+    | SConst ({exp_sconst_val = s;
+               exp_sconst_pos = pos}) ->
+      Gen.Profiling.push_time "[check_exp] SConst";
+      let c_e = CP.SConst (s, pos) in
+      let res_v = CP.Var (CP.mkRes string_type, pos) in
+      let c = CP.mkEqExp res_v c_e pos in
+      let c =
+        if !Globals.infer_lvar_slicing then
+          CP.set_il_formula c (Some (false, fresh_int(), [res_v]))
+        else c
+      in
+      let f = CF.formula_of_mix_formula (MCP.mix_of_pure c) pos in
+      let res_ctx = CF.normalize_max_renaming_list_failesc_context f pos true ctx in
+      Gen.Profiling.pop_time "[check_exp] SConst";
+      res_ctx
     | FConst {exp_fconst_val = f; exp_fconst_pos = pos} ->
       let c_e = CP.FConst (f, pos) in
       let res_v = CP.Var (CP.mkRes float_type, pos) in

--- a/typeinfer.ml
+++ b/typeinfer.ml
@@ -546,6 +546,10 @@ and gather_type_info_exp_x prog a0 tlist et =
     let t = I.int_type in
     let (n_tl,n_typ) = x_add must_unify_expect t et tlist pos in
     (n_tl,n_typ)
+  | IP.SConst (_,pos) ->
+    let t = I.string_type in
+    let (n_tl,n_typ) = x_add must_unify_expect t et tlist pos in
+    (n_tl,n_typ)
   | IP.FConst (_,pos) ->
     let t = I.float_type in
     let (n_tl,n_typ) = x_add must_unify_expect t et tlist pos in

--- a/z3.ml
+++ b/z3.ml
@@ -77,6 +77,7 @@ let rec smt_of_typ t =
   | Float -> "Int" (* Currently, do not support real arithmetic! *)
   | Tree_sh -> "Int"
   | Int -> "Int"
+  | String -> "String"
   | AnnT -> "Int"
   | UNK ->  "Int" (* illegal_format "z3.smt_of_typ: unexpected UNKNOWN type" *)
   | NUM -> "Int" (* Use default Int for NUM *)
@@ -115,6 +116,7 @@ let rec smt_of_exp a =
   | CP.Var (sv, _) -> smt_of_spec_var sv
   | CP.Level _ -> illegal_format ("z3.smt_of_exp: level should not appear here")
   | CP.IConst (i, _) -> if i >= 0 then string_of_int i else "(- 0 " ^ (string_of_int (0-i)) ^ ")"
+  | CP.SConst (s, _) -> "\"" ^ s ^ "\""
   | CP.AConst (i, _) -> string_of_int(int_of_heap_ann i)  (*string_of_heap_ann i*)
   | CP.FConst (f, _) -> string_of_float f 
   | CP.Add (a1, a2, _) -> "(+ " ^(smt_of_exp a1)^ " " ^ (smt_of_exp a2)^")"


### PR DESCRIPTION
Would fix #6. Allow for reasoning about constant strings, but not any string operations.