### PR TITLE
Print entailments in entailment format, remove trivial aliases

### DIFF
--- a/context.ml
+++ b/context.ml
@@ -4086,7 +4086,7 @@ and compute_actions prog estate es (* list of right aliases *)
     es lhs_h lhs_p rhs_lst rhs_p posib_r_alias
 
 
-and compute_actions_pretty prog estate es lhs_h lhs_p rhs_p posib_r_alias (rhs_lst : (CF.h_formula * CF.h_formula * MCP.mix_formula) list) is_normalizing (conseq:CF.formula) pos
+and compute_pretty_actions prog estate es lhs_h lhs_p rhs_p posib_r_alias (rhs_lst : (CF.h_formula * CF.h_formula * MCP.mix_formula) list) is_normalizing (conseq:CF.formula) pos
   : action =
   let pr = Cprinter.string_of_h_formula   in
   let pr3 = Cprinter.string_of_mix_formula in
@@ -4127,14 +4127,14 @@ and compute_actions_pretty prog estate es lhs_h lhs_p rhs_p posib_r_alias (rhs_l
    *   | One l -> List.iter show_match_res l
    *   | Many l -> List.iter show_match_res_level l
    * in *)
-  compute_actions_pretty_no_4 "compute_actions_pretty" pr pr3 pr1 pr3 pr2 (fun _ _ _ _ -> action) lhs_h lhs_p rhs_lst rhs_p
+  compute_pretty_actions_no_4 "compute_pretty_actions" pr pr3 pr1 pr3 pr2 (fun _ _ _ _ -> action) lhs_h lhs_p rhs_lst rhs_p
 
-and compute_actions_pretty_no_4 s p1 p2 p3 p4 p0 f e1 e2 e3 =
+and compute_pretty_actions_no_4 s p1 p2 p3 p4 p0 f e1 e2 e3 =
   let code_gen fn = fn s p1 p2 p3 p4 p0 f e1 e2 e3 in
   let code_none = Debug.ho_aux_no s (f e1 e2 e3) in
-  compute_actions_pretty_splitter s code_none code_gen compute_actions_pretty_go_4
+  compute_pretty_actions_splitter s code_none code_gen compute_pretty_actions_go_4
 
-and compute_actions_pretty_splitter s f_none f_gen f_norm =
+and compute_pretty_actions_splitter s f_none f_gen f_norm =
   let () = VarGen.last_posn # set_name s in
   let at_call_site =
     let x_call_site = VarGen.last_posn # get s in
@@ -4154,9 +4154,9 @@ and compute_actions_pretty_splitter s f_none f_gen f_norm =
       f_none in 
   if !Debug.dump_calls then Debug.wrap_pop_call fn else fn
 
-and compute_actions_pretty_go_4 t_flag l_flag s = compute_actions_pretty_ho_4_opt_aux t_flag [] l_flag (fun _ -> true) None s
+and compute_pretty_actions_go_4 t_flag l_flag s = compute_pretty_actions_ho_4_opt_aux t_flag [] l_flag (fun _ -> true) None s
 
-and compute_actions_pretty_ho_4_opt_aux df (flags:bool list) (loop_d:bool) (test:'z->bool) g (s:string) (pr1:'a->string) (pr2:'b->string) (pr3:'c->string) (pr4:'d->string) (pr_o:'z->string) 
+and compute_pretty_actions_ho_4_opt_aux df (flags:bool list) (loop_d:bool) (test:'z->bool) g (s:string) (pr1:'a->string) (pr2:'b->string) (pr3:'c->string) (pr4:'d->string) (pr_o:'z->string) 
     (f:'a -> 'b -> 'c -> 'd-> 'z) (e1:'a) (e2:'b) (e3:'c) (e4:'d): 'z =
   let call_site = VarGen.last_posn # get_rm s in
   let a1 = pr1 e1 in

--- a/context.ml
+++ b/context.ml
@@ -4081,6 +4081,56 @@ and compute_actions prog estate es (* list of right aliases *)
     (fun _ _ _ _ _ _ -> compute_actions_y prog estate es lhs_h lhs_p rhs_p posib_r_alias rhs_lst is_normalizing conseq pos)
     es lhs_h lhs_p rhs_lst rhs_p posib_r_alias
 
+
+and compute_actions_pretty prog estate es lhs_h lhs_p rhs_p posib_r_alias (rhs_lst : (CF.h_formula * CF.h_formula * MCP.mix_formula) list) is_normalizing (conseq:CF.formula) pos
+  : action =
+  let pr = Cprinter.string_of_h_formula   in
+  let pr3 = Cprinter.string_of_mix_formula in
+  let pr1 xs = String.concat " *" (List.map (fun (c1,_,_)-> Cprinter.string_of_h_formula c1) xs) in
+  let pr2 = string_of_action_res in
+  let action = compute_actions_y prog estate es lhs_h lhs_p rhs_p posib_r_alias rhs_lst is_normalizing conseq pos in
+  compute_actions_pretty_no_4 "compute_actions_pretty" pr pr3 pr1 pr3 pr2 (fun _ _ _ _ -> action) lhs_h lhs_p rhs_lst rhs_p
+
+and compute_actions_pretty_no_4 s p1 p2 p3 p4 p0 f e1 e2 e3 =
+  let code_gen fn = fn s p1 p2 p3 p4 p0 f e1 e2 e3 in
+  let code_none = Debug.ho_aux_no s (f e1 e2 e3) in
+  compute_actions_pretty_splitter s code_none code_gen compute_actions_pretty_go_4
+
+and compute_actions_pretty_splitter s f_none f_gen f_norm =
+  let () = VarGen.last_posn # set_name s in
+  let at_call_site =
+    let x_call_site = VarGen.last_posn # get s in
+    if x_call_site = "" then "" else " @" ^ x_call_site
+  in
+  let () = if !Debug.dump_callers_flag then Debug.debug_calls # push_call s at_call_site in
+  let () = if !Debug.dump_calls then Debug.debug_calls # print_call s at_call_site in
+  let fn =
+    if !VarGen.z_debug_flag then
+      match (Debug.in_debug s) with
+      | DO_Normal -> f_gen (f_norm false false)
+      | DO_Trace -> f_gen (f_norm true false) 
+      | DO_Loop -> f_gen (f_norm false true)
+      | DO_Both -> f_gen (f_norm true true)
+      | DO_None -> f_none
+    else
+      f_none in 
+  if !Debug.dump_calls then Debug.wrap_pop_call fn else fn
+
+and compute_actions_pretty_go_4 t_flag l_flag s = compute_actions_pretty_ho_4_opt_aux t_flag [] l_flag (fun _ -> true) None s
+
+and compute_actions_pretty_ho_4_opt_aux df (flags:bool list) (loop_d:bool) (test:'z->bool) g (s:string) (pr1:'a->string) (pr2:'b->string) (pr3:'c->string) (pr4:'d->string) (pr_o:'z->string) 
+    (f:'a -> 'b -> 'c -> 'd-> 'z) (e1:'a) (e2:'b) (e3:'c) (e4:'d): 'z =
+  let call_site = VarGen.last_posn # get_rm s in
+  let a1 = pr1 e1 in
+  let a2 = pr2 e2 in
+  let a3 = pr3 e3 in
+  let a4 = pr4 e4 in
+  let lz = Debug.choose flags [(1,lazy (pr1 e1)); (2,lazy (pr2 e2)); (3,lazy (pr3 e3)); (4,lazy (pr4 e4))] in
+  let f  = f e1 e2 e3 in
+  let g  = match g with None -> None | Some g -> Some (g e1 e2 e3) in
+  Debug.ho_aux ~call_site:call_site df lz loop_d test g s [a1^" &"^a2^" |-"^a3^" &"^a4] pr_o f e4
+
+
 and input_formula_in2_frame (frame, id_hole) (to_input : formula) : formula =
   match to_input with
   | Base (fb) ->

--- a/context.ml
+++ b/context.ml
@@ -51,6 +51,10 @@ type match_res = {
   match_res_compatible: (CP.spec_var * CP.spec_var) list; (* for infer_unfold (unkown pred, unkown pred), rhs args are inst with lhs args *)
 }
 
+(* and match_res_level =
+ *   | One of match_res list
+ *   | Many of match_res_level list *)
+
 (*
 type context = (h_formula (* frame with a hole *)
 		* h_formula (* formula from the hole *)
@@ -4089,6 +4093,40 @@ and compute_actions_pretty prog estate es lhs_h lhs_p rhs_p posib_r_alias (rhs_l
   let pr1 xs = String.concat " *" (List.map (fun (c1,_,_)-> Cprinter.string_of_h_formula c1) xs) in
   let pr2 = string_of_action_res in
   let action = compute_actions_y prog estate es lhs_h lhs_p rhs_p posib_r_alias rhs_lst is_normalizing conseq pos in
+  (* let rec get_match_res_level_of_action (a: action): match_res_level =
+   *   match a with
+   *   | M_match e -> One [e]
+   *   | M_split_match e -> One [e]
+   *   | M_fold e -> One [e]
+   *   | M_acc_fold (e,_) -> One [e]
+   *   | M_unfold (e,_) -> One [e]
+   *   | M_base_case_unfold e -> One [e]
+   *   | M_base_case_fold e -> One [e]
+   *   | M_seg_fold (e,_) -> One [e]
+   *   | M_rd_lemma e -> One [e]
+   *   | M_lemma (e,_,_) -> One [e]
+   *   | Undefined_action e -> One [e]
+   *   | M_Nothing_to_do _ -> One []
+   *   | M_infer_unfold (e,_,_) -> One [e]
+   *   | M_infer_fold (_,e) -> One [e]
+   *   | M_infer_heap (_,h1,h2,h3) -> One []
+   *   | M_unmatched_rhs_data_node (h1,h2,_) ->  One []
+   *   | Cond_action l -> Many (List.map (fun (w,a) -> get_match_res_level_of_action a) l)
+   *   | Seq_action l -> Many (List.map (fun (w,a) -> get_match_res_level_of_action a) l)
+   *   | Search_action l -> Many (List.map (fun (w,a) -> get_match_res_level_of_action a) l)
+   *   | M_lhs_case e -> One [e]
+   *   | M_ramify_lemma e -> One [e]
+   *   | M_cyclic (e,_,_,_,_) -> One [e]
+   * in
+   * let rec show_match_res (c: match_res): unit =
+   *   pr_hwrap "" pr_h_formula c.match_res_lhs_node; fmt_cut ();
+   *   pr_hwrap "" pr_h_formula c.match_res_rhs_node; fmt_cut ();
+   *   fmt_close ()
+   * and show_match_res_level (c: match_res_level): unit =
+   *   match c with
+   *   | One l -> List.iter show_match_res l
+   *   | Many l -> List.iter show_match_res_level l
+   * in *)
   compute_actions_pretty_no_4 "compute_actions_pretty" pr pr3 pr1 pr3 pr2 (fun _ _ _ _ -> action) lhs_h lhs_p rhs_lst rhs_p
 
 and compute_actions_pretty_no_4 s p1 p2 p3 p4 p0 f e1 e2 e3 =

--- a/context.ml
+++ b/context.ml
@@ -4166,7 +4166,7 @@ and compute_actions_pretty_ho_4_opt_aux df (flags:bool list) (loop_d:bool) (test
   let lz = Debug.choose flags [(1,lazy (pr1 e1)); (2,lazy (pr2 e2)); (3,lazy (pr3 e3)); (4,lazy (pr4 e4))] in
   let f  = f e1 e2 e3 in
   let g  = match g with None -> None | Some g -> Some (g e1 e2 e3) in
-  Debug.ho_aux ~call_site:call_site df lz loop_d test g s [a1^" &"^a2^" |-"^a3^" &"^a4] pr_o f e4
+  Debug.ho_aux ~call_site:call_site df lz loop_d test g s ["[e|"^a1^" &"^a2^" |-"^a3^" &"^a4^"|e]"] pr_o f e4
 
 
 and input_formula_in2_frame (frame, id_hole) (to_input : formula) : formula =

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -22,7 +22,7 @@ grammar = Grammar(
     alias = exp"="exp
     boolPred = exp"("exp")"
     heapPred = (space? "emp" space?) / (exp"::"exp"<"exp">@M")
-    exp = (var times var) / (var plus var) / var
+    exp = (var times exp) / (var plus exp) / var
     var = ~r"[a-zA-Z0-9_]+"
     proves = space? "|-" space?
     star = space? "*" space?

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-# Entailments are of the form `[e|A * B & C |- D * E & F|e]`, where `A,B,C,D,E,F` are predicates, `*,&` are operators, and `|-` is the entailment symbol.
+# Entailments are of the form `[e|A * B & C |- D * E & F|e]`, where `A,B,C,D,E,F` are either boolean expressions or predicates, `*,&` are operators, and `|-` is the entailment symbol.
 # It is assumed that all variables in the entailment have unique names.
-# Aliases are predicates of the form `alias=value`.
+# Aliases are boolean expressions of the form `alias=value`.
 # This script has three steps:
 # 1. Read line from input.
 # 2. Go to step 3 if line is not an entailment. Else, replace in `line` all occurences of `alias` with `value`, and remove from `line` all aliases.

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -26,7 +26,8 @@ grammar = Grammar(
     notAlias = "!("exp"="exp")"
     boolPred = exp"("exp")"
     heapPred = (space? "emp" space?) / (exp"::"exp"<"exp">@M")
-    exp = (var (times/plus) exp) / ("(" var (times/plus) exp ")") / var
+    exp = (var ((times/plus) exp)*) / (expEnclosed ((times/plus) exp)*)
+    expEnclosed = "(" exp ((times/plus) exp)* ")"
     var = ~r"[a-zA-Z0-9_]+"
     proves = space? "|-" space?
     star = space? "*" space?

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -72,6 +72,28 @@ class VarReplacer(NodeVisitor):
     def generic_visit(self, node, visited_children):
         return ''.join(visited_children) if visited_children else node.text
 
+class AliasRemover(NodeVisitor):
+    """Remove a trivial alias, and also remove the operator before (if available).
+    """
+
+    """TODO remove trivial alias at the start of `handside`.
+    def visit_handside(self, node, visited_children):
+        ...
+    """
+
+    def visit_handsideRest(self, node, visited_children):
+        operator, operand, _ = node.children[0]
+        if operand.expr_name == 'boolExp':
+            child = operand.children[0]
+            if child.expr_name == 'alias':
+                alias, _, value = child
+                if alias.text == value.text:
+                    return ''
+        return ''.join(visited_children)
+
+    def generic_visit(self, node, visited_children):
+        return ''.join(visited_children) if visited_children else node.text
+
 if __name__ == '__main__':
 
     # Step 1.
@@ -129,6 +151,10 @@ if __name__ == '__main__':
                 if entailmentOld == entailment:
                     break
                 entailmentOld = entailment
+
+            tree = grammar.parse(entailment)
+            ar = AliasRemover()
+            entailment = ar.visit(tree)
 
             # Step 3.
             print(entailment)

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -19,7 +19,7 @@ grammar = Grammar(
     entailment = space? handside proves handside space?
     handside = (boolExp handsideRest?) / (heapPred handsideRest?)
     handsideRest = (and boolExp handsideRest*) / (star heapPred handsideRest*)
-    boolExp = alias / boolPred / (exp"<"exp) / (exp">"exp) / (exp"<="exp) / (exp">="exp)
+    boolExp = "true" / "false" / alias / boolPred / (exp"<"exp) / (exp">"exp) / (exp"<="exp) / (exp">="exp)
     alias = exp"="exp
     boolPred = exp"("exp")"
     heapPred = (space? "emp" space?) / (exp"::"exp"<"exp">@M")

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -9,6 +9,28 @@
 # 3. Print line (possibly with aliases removed) to output.
 
 from sys import stdin
+from parsimonious.grammar import Grammar
+from parsimonious.exceptions import ParseError
+
+# `handside` stands for both "left hand side" and "right hand side".
+grammar = Grammar(
+    r"""
+    entailment = space? handside proves handside space?
+    handside = (boolExp handsideRest?) / (heapPred handsideRest?)
+    handsideRest = (and boolExp handsideRest*) / (star heapPred handsideRest*)
+    boolExp = alias / boolPred / (exp"<"exp) / (exp">"exp) / (exp"<="exp) / (exp">="exp)
+    alias = exp"="exp
+    boolPred = exp"("exp")"
+    heapPred = (space? "emp" space?) / (exp"::"exp"<"exp">@M")
+    exp = (var times var) / (var plus var) / var
+    var = ~r"[a-zA-Z0-9_]+"
+    proves = space? "|-" space?
+    star = space? "*" space?
+    and = space? "&" space?
+    times = space? "*" space?
+    plus = space? "+" space?
+    space = ~r"\s+"
+    """)
 
 openSymbol='[e|'
 closeSymbol='|e]'
@@ -70,7 +92,8 @@ if __name__ == '__main__':
                 raise Exception('Unhandled case')
 
             entailment = ''.join(map(lambda x: x.strip(), entailmentChunks))
-            print('entailment:', entailment)
 
             # Step 2.
             # TODO
+            print(entailment)
+            print(grammar.parse(entailment))

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -4,9 +4,9 @@
 # It is assumed that all variables in the entailment have unique names.
 # Aliases are boolean expressions of the form `alias=value`.
 # This script has three steps:
-# 1. Read line from input.
+# 1. Read line from input, and print same line to output.
 # 2. Go to step 3 if line is not an entailment. Else, replace in `line` all occurences of `alias` with `value`, and remove from `line` all aliases.
-# 3. Print line (possibly with aliases removed) to output.
+# 3. Maybe print line (possibly with aliases removed) to output.
 
 from sys import stdin
 from parsimonious.grammar import Grammar
@@ -76,6 +76,7 @@ if __name__ == '__main__':
 
     # Step 1.
     for line in stdin:
+        print(line, end='')
 
         # Although get multiple index of `openSymbol` and `closeSymbol` with intention to iterate through all combinations,
         # assume for now that `openSymbol` and `closeSymbol` are unique to entailments, and not used anywhere else.
@@ -87,12 +88,7 @@ if __name__ == '__main__':
         isNotEntailment = len(indexesOpen) == 0 and len(indexesClose) == 0
         isSpanOne = len(indexesOpen) == 1 and len(indexesClose) == 1
         isSpanMany = len(indexesOpen) == 1 and len(indexesClose) == 0
-        if isNotEntailment:
-
-            # Step 3.
-            print(line, end='')
-
-        else:
+        if not isNotEntailment:
 
             # Extract entailments that possibly span multiple lines.
             entailmentChunks = []
@@ -122,7 +118,6 @@ if __name__ == '__main__':
             entailment = ''.join(map(lambda x: x.strip(), entailmentChunks))
 
             # Step 2.
-            print(entailment)
             # Repeat until fixpoint.
             entailmentOld = entailment
             while True:

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -19,8 +19,9 @@ grammar = Grammar(
     entailment = space? handside proves handside space?
     handside = (boolExp handsideRest?) / (heapPred handsideRest?)
     handsideRest = (and boolExp handsideRest*) / (star heapPred handsideRest*)
-    boolExp = "true" / "false" / alias / boolPred / (exp"<"exp) / (exp">"exp) / (exp"<="exp) / (exp">="exp)
+    boolExp = "true" / "false" / alias / notAlias / boolPred / (exp"<"exp) / (exp">"exp) / (exp"<="exp) / (exp">="exp)
     alias = exp"="exp
+    notAlias = "!("exp"="exp")"
     boolPred = exp"("exp")"
     heapPred = (space? "emp" space?) / (exp"::"exp"<"exp">@M")
     exp = (var times exp) / (var plus exp) / ("(" var times exp ")") / ("(" var plus exp ")") / var

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -23,7 +23,7 @@ grammar = Grammar(
     alias = exp"="exp
     boolPred = exp"("exp")"
     heapPred = (space? "emp" space?) / (exp"::"exp"<"exp">@M")
-    exp = (var times exp) / (var plus exp) / var
+    exp = (var times exp) / (var plus exp) / ("(" var times exp ")") / ("(" var plus exp ")") / var
     var = ~r"[a-zA-Z0-9_]+"
     proves = space? "|-" space?
     star = space? "*" space?

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# Entailments are of the form `A * B & C |- D * E & F`, where `A,B,C,D,E,F` are predicates, `*,&` are operators, and `|-` is the entailment symbol.
+# It is assumed that all variables in the entailment have unique names.
+# Aliases are predicates of the form `alias=value`.
+# This script has three steps:
+# 1. Read line from input.
+# 2. Go to step 3 if line is not an entailment. Else, replace in `line` all occurences of `alias` with `value`, and remove from `line` all aliases.
+# 3. Print line (possibly with aliases removed) to output.
+
+import sys
+
+entailSymbol=' |- '
+aliasSymbol='='
+operatorSymbols=['*', '&']
+
+if __name__ == '__main__':
+
+    # Step 1.
+    for line in sys.stdin:
+
+        # Step 2.
+        if entailSymbol in line:
+
+            # Replace all occurences of `alias` with `value`.
+            tokens = line.split(' ')
+            for i in range(len(tokens)):
+                token = tokens[i]
+                if aliasSymbol in token:
+                    (alias, value) = token.split(aliasSymbol)
+
+                    # Although all variables have unique names, the following is not correct,
+                    # since variables `b` and `b_107` have unique names, but with an alias `b=a`,
+                    # then string replacement will convert the variable `b_107` into `a_107`.
+                    # But to avoid parsing, this is the best solution.
+                    line = line.replace(alias, value)
+
+            # Remove all aliases.
+            # Remove an alias, and also remove the operator before (if available).
+            tokens = line.split(' ')
+            tokensNoAliases = []
+            for i in range(len(tokens)):
+                token = tokens[i]
+                if aliasSymbol in token:
+                    (alias, value) = token.split(aliasSymbol)
+                    if alias == value:
+                        # Do not add to tokensNoAliases.
+                        # Try to remove operator before.
+                        if i-1 >= 0 and tokens[i-1] in operatorSymbols:
+                            tokensNoAliases.pop()
+                    else:
+                        tokensNoAliases.append(token)
+                else:
+                    tokensNoAliases.append(token)
+
+            # Collect tokensNoAliases.
+            line = ' '.join(tokensNoAliases)
+
+        # Step 3.
+        print(line, end='')

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -52,8 +52,6 @@ if __name__ == '__main__':
 
             elif isSpanMany:
 
-                # Assume line ends with '\n'. Remove trailing '\n'.
-                line = line[:-1]
                 entailmentChunks.append(line[indexesOpen[0]+len(openSymbol):])
                 for line in stdin:
                     indexesOpen = get_indexes(line, openSymbol)
@@ -66,14 +64,12 @@ if __name__ == '__main__':
                         entailmentChunks.append(line[:indexesClose[0]])
                         break
                     else:
-                        # Assume line ends with '\n'. Remove trailing '\n'.
-                        line = line[:-1]
                         entailmentChunks.append(line)
 
             else:
                 raise Exception('Unhandled case')
 
-            entailment = ''.join(entailmentChunks)
+            entailment = ''.join(map(lambda x: x.strip(), entailmentChunks))
             print('entailment:', entailment)
 
             # Step 2.

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -83,13 +83,15 @@ class AliasRemover(NodeVisitor):
     """
 
     def visit_handsideRest(self, node, visited_children):
-        operator, operand, _ = node.children[0]
+        operator, operand, rest = node.children[0]
         if operand.expr_name == 'boolExp':
             child = operand.children[0]
             if child.expr_name == 'alias':
                 alias, _, value = child
                 if alias.text == value.text:
-                    return ''
+                    return '' # TODO do something with `rest`
+                else:
+                    return ''.join(visited_children)
         return ''.join(visited_children)
 
     def generic_visit(self, node, visited_children):

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -21,12 +21,12 @@ grammar = Grammar(
     handsideHead = boolExp / heapPred
     handsideRest = handsideRestHead handsideRest*
     handsideRestHead = (and boolExp) / (star heapPred)
-    boolExp = "true" / "false" / alias / notAlias / boolPred / (exp"<"exp) / (exp">"exp) / (exp"<="exp) / (exp">="exp)
+    boolExp = "true" / "false" / alias / notAlias / boolPred / (exp ("<"/">"/"<="/">=") exp)
     alias = exp"="exp
     notAlias = "!("exp"="exp")"
     boolPred = exp"("exp")"
     heapPred = (space? "emp" space?) / (exp"::"exp"<"exp">@M")
-    exp = (var times exp) / (var plus exp) / ("(" var times exp ")") / ("(" var plus exp ")") / var
+    exp = (var (times/plus) exp) / ("(" var (times/plus) exp ")") / var
     var = ~r"[a-zA-Z0-9_]+"
     proves = space? "|-" space?
     star = space? "*" space?

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Entailments are of the form `A * B & C |- D * E & F`, where `A,B,C,D,E,F` are predicates, `*,&` are operators, and `|-` is the entailment symbol.
+# Entailments are of the form `[e|A * B & C |- D * E & F|e]`, where `A,B,C,D,E,F` are predicates, `*,&` are operators, and `|-` is the entailment symbol.
 # It is assumed that all variables in the entailment have unique names.
 # Aliases are predicates of the form `alias=value`.
 # This script has three steps:

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -121,7 +121,10 @@ if __name__ == '__main__':
             elif isSpanMany:
 
                 entailmentChunks.append(line[indexesOpen[0]+len(openSymbol):])
+
+                # Step 1.
                 for line in stdin:
+                    print(line, end='')
                     indexesOpen = get_indexes(line, openSymbol)
                     indexesClose = get_indexes(line, closeSymbol)
                     isIllegal = len(indexesOpen) == 1

--- a/solver.ml
+++ b/solver.ml
@@ -11630,7 +11630,7 @@ and heap_entail_non_empty_rhs_heap_x ?(caller="") ?(cont_act=[]) prog is_folding
                posib_r_alias rhs_lst estate.es_is_normalizing conseq pos,[])
     | (_,a)::lst -> (a,lst)
   in
-  let _ = x_add Context.compute_actions_pretty prog estate rhs_eqset lhs_h lhs_p rhs_p posib_r_alias rhs_lst estate.es_is_normalizing conseq pos in
+  let _ = x_add Context.compute_pretty_actions prog estate rhs_eqset lhs_h lhs_p rhs_p posib_r_alias rhs_lst estate.es_is_normalizing conseq pos in
   let () = x_tinfo_hp (add_str "actions" Context.string_of_action_res) actions  no_pos in
   (* let () = x_tinfo_hp (add_str " xxxxxxxxxxxxxx1" pr_id) "END"  no_pos in *)
   (* !!!!!!!!

--- a/solver.ml
+++ b/solver.ml
@@ -11626,7 +11626,7 @@ and heap_entail_non_empty_rhs_heap_x ?(caller="") ?(cont_act=[]) prog is_folding
   let () = x_tinfo_hp (add_str "ctx0" Cprinter.string_of_context_short) ctx0  no_pos in
   let () = x_tinfo_hp (add_str "estate.es_folding_conseq_pure " (pr_option Cprinter.string_of_mix_formula)) estate.es_folding_conseq_pure pos in
   let actions,cont_act = match cont_act with
-      [] -> (x_add Context.compute_actions prog estate rhs_eqset lhs_h lhs_p rhs_p
+      [] -> (x_add Context.compute_actions_pretty prog estate rhs_eqset lhs_h lhs_p rhs_p
                posib_r_alias rhs_lst estate.es_is_normalizing conseq pos,[])
     | (_,a)::lst -> (a,lst)
   in

--- a/solver.ml
+++ b/solver.ml
@@ -11626,10 +11626,11 @@ and heap_entail_non_empty_rhs_heap_x ?(caller="") ?(cont_act=[]) prog is_folding
   let () = x_tinfo_hp (add_str "ctx0" Cprinter.string_of_context_short) ctx0  no_pos in
   let () = x_tinfo_hp (add_str "estate.es_folding_conseq_pure " (pr_option Cprinter.string_of_mix_formula)) estate.es_folding_conseq_pure pos in
   let actions,cont_act = match cont_act with
-      [] -> (x_add Context.compute_actions_pretty prog estate rhs_eqset lhs_h lhs_p rhs_p
+      [] -> (x_add Context.compute_actions prog estate rhs_eqset lhs_h lhs_p rhs_p
                posib_r_alias rhs_lst estate.es_is_normalizing conseq pos,[])
     | (_,a)::lst -> (a,lst)
   in
+  let _ = x_add Context.compute_actions_pretty prog estate rhs_eqset lhs_h lhs_p rhs_p posib_r_alias rhs_lst estate.es_is_normalizing conseq pos in
   let () = x_tinfo_hp (add_str "actions" Context.string_of_action_res) actions  no_pos in
   (* let () = x_tinfo_hp (add_str " xxxxxxxxxxxxxx1" pr_id) "END"  no_pos in *)
   (* !!!!!!!!


### PR DESCRIPTION
# Summary
This output from `sleek`:
```
compute_pretty_actions inp1 :[e| b_134::int_star<v_142>@M * c_133::aseg<flted_18_141>@M & flted_18_141=n_131+a & flted_159_96=n_131+a & b_134=k_132+a &
 c_133=1+b_134 & Univ(n_131) & Univ(k_132) & Univ(c_133) & Univ(b_134) &
 b=3+a & flted_159_96=4+a |- b::int_star<v>@M & b_109=b|e]
```
gets converted to:
```
k_132+a::int_star<v_142>@M * 1+b_134::aseg<n_131+a>@M &1+b_134=1+k_132+a & Univ(n_131) & Univ(k_132) & Univ(1+b_134) & Univ(k_132+a) & n_131+a=4+a |- 3+a::int_star<v>@M
```

# Details
A typical output of `./sleek -dre=compute_actions` is:
```
(==solver.ml#11629==)
compute_actions@1
compute_actions inp1 :EQ ptr:[(b_107,b)]
compute_actions inp2 :LHS heap: a::aseg<flted_109_94>@M
compute_actions inp3 :LHS pure: b=1+a & flted_109_94=2+a
compute_actions inp4 :RHS cand:[ a::aseg<b_107>@M, b::int_star<v>@M]
compute_actions inp5 :RHS pure: b_107=b
compute_actions inp6 :right alias:[b_107,v]
```
This output is clearly an entailment (with LHS and RHS), but is not in a user-friendly entailment format of `A * B & C |- D * E & F`. The changes in `solver.ml` and `context.ml` does this.

Furthermore, larger entailments can have many aliases, and the user has to ignore or remove these in order to understand the meaning of the entailment. Alias substitution and removal is done by the new script `remove-aliases.py`, which recognizes aliases of the format `[e| A * B & C |- D * E & F |e]`.

The Oxford brackets `[e|` and `|e]` are as in quasi-quotation, inspired by Template Haskell. The motivation of Oxford brackets is to have the entailment that may contain trivial aliases stand for the entailment containing no trivial aliases. The letter `e` within the Oxford brackets allow unique identification of the string inside the Oxford brackets as an entailment that may contain trivial aliases.

## Possible Issues
The idea of commit 793b106 is to avoid changing the behavior of hipsleek wrt before this pull request (in contrast to 53b7c4f, which replaces the call to `compute_actions` by `compute_actions_pretty`, where `compute_actions_pretty` is identical to `compute_actions`, except for the outputted format). However, I'm not sure if the call `x_add Context.compute_pretty_actions ...` in 793b106 changes any behavior.