### PR TITLE
Various improvements to `remove-aliases.py`

### DIFF
--- a/context.ml
+++ b/context.ml
@@ -4166,7 +4166,7 @@ and compute_pretty_actions_ho_4_opt_aux df (flags:bool list) (loop_d:bool) (test
   let lz = Debug.choose flags [(1,lazy (pr1 e1)); (2,lazy (pr2 e2)); (3,lazy (pr3 e3)); (4,lazy (pr4 e4))] in
   let f  = f e1 e2 e3 in
   let g  = match g with None -> None | Some g -> Some (g e1 e2 e3) in
-  Debug.ho_aux ~call_site:call_site df lz loop_d test g s ["[e|"^a1^" &"^a2^" |-"^a3^" &"^a4^"|e]"] pr_o f e4
+  Debug.ho_aux ~call_site:call_site df lz loop_d test g s ["[f|"^a1^" &"^a2^" |-"^a3^" &"^a4^"|f]"] pr_o f e4
 
 
 and input_formula_in2_frame (frame, id_hole) (to_input : formula) : formula =

--- a/globals.ml
+++ b/globals.ml
@@ -974,6 +974,7 @@ let simpl_unfold2 = ref false
 let simpl_unfold1 = ref false
 let simpl_memset = ref false
 
+let pretty_print = ref false
 let simplify_dprint = ref true
 
 let print_heap_pred_decl = ref true

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -15,10 +15,10 @@ from parsimonious.exceptions import ParseError
 
 grammar = Grammar(
     r"""
-    entailment = head rest?
-    head = space? (heapPred / boolExp) space?
-    rest = restHead rest*
-    restHead = space? operatorsTop space? (heapPred / boolExp) space?
+    entailment = space? head rest? space?
+    head = heapPred / boolExp
+    rest = space? restHead space? rest*
+    restHead = operatorsTop (heapPred / boolExp)
     heapPred = "emp" / (exp "::" exp "<" exp? ">@M")
     boolExp = "true" / "false" / alias / notAlias / boolPred / boolCompare / quantifierPred
     alias = exp "=" exp
@@ -28,9 +28,9 @@ grammar = Grammar(
     quantifierPred = exp "(" exp ":" entailment ")"
     exp = (var (operatorsExp exp)*) / (expEnclosed (operatorsExp exp)*)
     expEnclosed = "(" exp ")"
-    operatorsTop = "|-" / "*" / "&"
-    operatorsCompare = "<=" / ">=" / "<" / ">"
-    operatorsExp = "*" / "+" / "-"
+    operatorsTop = space? ("|-" / "*" / "&") space?
+    operatorsCompare = space? ("<=" / ">=" / "<" / ">") space?
+    operatorsExp = space? ("*" / "+" / "-") space?
     var = ~r"[a-zA-Z0-9_]+"
     space = ~r"\s+"
     """)

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -21,7 +21,7 @@ grammar = Grammar(
     handsideHead = boolExp / heapPred
     handsideRest = handsideRestHead handsideRest*
     handsideRestHead = (and boolExp) / (star heapPred)
-    boolExp = "true" / "false" / alias / notAlias / boolPred / ((exp/expEnclosed) ("<"/">"/"<="/">=") (exp/expEnclosed))
+    boolExp = "true" / "false" / alias / notAlias / boolPred / ((exp/expEnclosed) ("<="/">="/"<"/">") (exp/expEnclosed))
     alias = exp"="exp
     notAlias = "!("exp"="exp")"
     boolPred = exp"("exp")"

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -29,7 +29,7 @@ grammar = Grammar(
     expEnclosed = "(" exp ")"
     operatorsTop = "|-" / "*" / "&"
     operatorsCompare = "<=" / ">=" / "<" / ">"
-    operatorsExp = "*" / "+"
+    operatorsExp = "*" / "+" / "-"
     var = ~r"[a-zA-Z0-9_]+"
     space = ~r"\s+"
     """)

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -21,7 +21,7 @@ grammar = Grammar(
     handsideHead = boolExp / heapPred
     handsideRest = handsideRestHead handsideRest*
     handsideRestHead = (and boolExp) / (star heapPred)
-    boolExp = "true" / "false" / alias / notAlias / boolPred / (exp ("<"/">"/"<="/">=") exp)
+    boolExp = "true" / "false" / alias / notAlias / boolPred / ((exp/expEnclosed) ("<"/">"/"<="/">=") (exp/expEnclosed))
     alias = exp"="exp
     notAlias = "!("exp"="exp")"
     boolPred = exp"("exp")"

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -18,15 +18,18 @@ grammar = Grammar(
     entailment = head rest?
     head = space? (heapPred / boolExp) space?
     rest = restHead rest*
-    restHead = space? ("|-" / "*" / "&") space? (heapPred / boolExp) space?
+    restHead = space? operatorsTop space? (heapPred / boolExp) space?
     heapPred = "emp" / (exp "::" exp "<" exp? ">@M")
     boolExp = "true" / "false" / alias / notAlias / boolPred / boolCompare
     alias = exp "=" exp
     notAlias = "!(" exp "=" exp ")"
     boolPred = exp "(" exp ")"
-    boolCompare = (exp ("<=" / ">=" / "<" / ">") exp)
-    exp = (var (("*" / "+") exp)*) / (expEnclosed (("*" / "+") exp)*)
+    boolCompare = exp operatorsCompare exp
+    exp = (var (operatorsExp exp)*) / (expEnclosed (operatorsExp exp)*)
     expEnclosed = "(" exp ")"
+    operatorsTop = "|-" / "*" / "&"
+    operatorsCompare = "<=" / ">=" / "<" / ">"
+    operatorsExp = "*" / "+"
     var = ~r"[a-zA-Z0-9_]+"
     space = ~r"\s+"
     """)

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -152,6 +152,7 @@ if __name__ == '__main__':
                 raise Exception('Unhandled case')
 
             entailment = ''.join(map(lambda x: x.strip(), entailmentChunks))
+            entailment = entailment.split('&{FLOW,(20,21)=__norm#E}[]', 1)[0]
 
             # Step 2.
             # Repeat until fixpoint.

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -91,7 +91,7 @@ class AliasRemover(NodeVisitor):
         return ''.join(visited_children)
 
     def visit_restHead(self, node, visited_children):
-        _, operand = node.children[0]
+        _, operand = node.children
         if operand.expr_name == 'boolExp':
             child = operand.children[0]
             if child.expr_name == 'alias':

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -25,7 +25,7 @@ grammar = Grammar(
     alias = exp"="exp
     notAlias = "!("exp"="exp")"
     boolPred = exp"("exp")"
-    heapPred = (space? "emp" space?) / (exp"::"exp"<"exp">@M")
+    heapPred = (space? "emp" space?) / (exp"::"exp"<"exp?">@M")
     exp = (var ((times/plus) exp)*) / (expEnclosed ((times/plus) exp)*)
     expEnclosed = "(" exp ((times/plus) exp)* ")"
     var = ~r"[a-zA-Z0-9_]+"

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -20,11 +20,12 @@ grammar = Grammar(
     rest = restHead rest*
     restHead = space? operatorsTop space? (heapPred / boolExp) space?
     heapPred = "emp" / (exp "::" exp "<" exp? ">@M")
-    boolExp = "true" / "false" / alias / notAlias / boolPred / boolCompare
+    boolExp = "true" / "false" / alias / notAlias / boolPred / boolCompare / quantifierPred
     alias = exp "=" exp
     notAlias = "!(" exp "=" exp ")"
     boolPred = exp "(" exp ")"
     boolCompare = exp operatorsCompare exp
+    quantifierPred = exp "(" exp ":" entailment ")"
     exp = (var (operatorsExp exp)*) / (expEnclosed (operatorsExp exp)*)
     expEnclosed = "(" exp ")"
     operatorsTop = "|-" / "*" / "&"

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Aliased statements are of the form `[e| A * B & C |e]`, where `A,B,C` are operands, and `*,&` are operators.
+# Aliased statements are of the form `[f| A * B & C |f]`, where `A,B,C` are operands, and `*,&` are operators.
 # It is assumed that all variables in the entailment have unique names.
 # Aliases are boolean expressions of the form `alias=value`.
 # This script has three steps:
@@ -31,8 +31,8 @@ grammar = Grammar(
     space = ~r"\s+"
     """)
 
-openSymbol='[e|'
-closeSymbol='|e]'
+openSymbol='[f|'
+closeSymbol='|f]'
 
 def get_indexes(line, symbol):
     indexes = []

--- a/scriptarguments.ml
+++ b/scriptarguments.ml
@@ -58,6 +58,8 @@ let set_frontend fe_str = match fe_str  with
 
 (* arguments/flags that might be used both by sleek and hip *)
 let common_arguments = [
+  ("--pprint", Arg.Set Globals.pretty_print,
+   "Pretty print.");
   ("--sctx", Arg.Set Typechecker.simplify_context, "Simplify the context before each execution in symbolic execution."); (* An Hoa *)
   ("--sdp", Arg.Set Globals.simplify_dprint,
    "Simplify the entail state before printing the dprint state."); (* An Hoa *)

--- a/solver.ml
+++ b/solver.ml
@@ -11626,11 +11626,12 @@ and heap_entail_non_empty_rhs_heap_x ?(caller="") ?(cont_act=[]) prog is_folding
   let () = x_tinfo_hp (add_str "ctx0" Cprinter.string_of_context_short) ctx0  no_pos in
   let () = x_tinfo_hp (add_str "estate.es_folding_conseq_pure " (pr_option Cprinter.string_of_mix_formula)) estate.es_folding_conseq_pure pos in
   let actions,cont_act = match cont_act with
-      [] -> (x_add Context.compute_actions prog estate rhs_eqset lhs_h lhs_p rhs_p
-               posib_r_alias rhs_lst estate.es_is_normalizing conseq pos,[])
+      [] -> if !Globals.pretty_print then
+        (x_add Context.compute_pretty_actions prog estate rhs_eqset lhs_h lhs_p rhs_p posib_r_alias rhs_lst estate.es_is_normalizing conseq pos,[])
+      else
+        (x_add Context.compute_actions prog estate rhs_eqset lhs_h lhs_p rhs_p posib_r_alias rhs_lst estate.es_is_normalizing conseq pos,[])
     | (_,a)::lst -> (a,lst)
   in
-  let _ = x_add Context.compute_pretty_actions prog estate rhs_eqset lhs_h lhs_p rhs_p posib_r_alias rhs_lst estate.es_is_normalizing conseq pos in
   let () = x_tinfo_hp (add_str "actions" Context.string_of_action_res) actions  no_pos in
   (* let () = x_tinfo_hp (add_str " xxxxxxxxxxxxxx1" pr_id) "END"  no_pos in *)
   (* !!!!!!!!


### PR DESCRIPTION
Rewrite grammar in preparation for removing aliases from more general strings, not just entailments.

Avoid side effects of calling `Context.compute_pretty_actions` by hiding the call behind a global flag. This flag is settable by the script argument `--pprint`.

The quasiquoted letter is now `f`, which stands for "formula".