### PR TITLE
Add more pretty printing

### DIFF
--- a/cprinter.ml
+++ b/cprinter.ml
@@ -3223,7 +3223,7 @@ let rec pr_numbered_list_formula_trace_ho_inst cprog (e:(context * (formula*form
       let turel = collect_tu_rel ctx in
       let term_err = collect_term_err ctx in
       fmt_open_vbox 0;
-      pr_wrap (fun _ -> fmt_string ("<" ^ (string_of_int count) ^ ">"); pr_formula a) ();
+      pr_wrap (fun _ -> fmt_string ("<" ^ (string_of_int count) ^ ">"); if !Globals.pretty_print then fmt_string "[f|"; pr_formula a; if !Globals.pretty_print then fmt_string "|f]") ();
       pr_wrap_test "" Gen.is_empty (pr_seq "" fmt_string) term_err;
       pr_wrap_test "inferred heap: " Gen.is_empty  (pr_seq "" pr_h_formula) (lh);
       pr_wrap_test "inferred templ: " Gen.is_empty  (pr_seq "" pr_templ_assume) lt;

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -92,8 +92,8 @@ class AliasRemover(NodeVisitor):
 
     def visit_restHead(self, node, visited_children):
         _, operand = node.children
-        if operand.expr_name == 'boolExp':
-            child = operand.children[0]
+        if operand.expr_name == 'head':
+            child = operand.children[0].children[0]
             if child.expr_name == 'alias':
                 alias, _, value = child
                 if alias.text == value.text:

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -78,11 +78,15 @@ class AliasRemover(NodeVisitor):
     """Remove a trivial alias, and also remove the operator before (if available).
     """
 
+    def __init__(self):
+        self.isTrivialAliasHead = False
+
     def visit_head(self, node, visited_children):
         operand = node.children[0].children[0]
         if operand.expr_name == 'alias':
             alias, _, value = operand
             if alias.text == value.text:
+                self.isTrivialAliasHead = True
                 return ''
             else:
                 return ''.join(visited_children)
@@ -97,8 +101,16 @@ class AliasRemover(NodeVisitor):
                 if alias.text == value.text:
                     return ''
                 else:
-                    return ''.join(visited_children)
-        return ''.join(visited_children)
+                    if self.isTrivialAliasHead:
+                        self.isTrivialAliasHead = False
+                        return ''.join(visited_children[1:])
+                    else:
+                        return ''.join(visited_children)
+        if self.isTrivialAliasHead:
+            self.isTrivialAliasHead = False
+            return ''.join(visited_children[1:])
+        else:
+            return ''.join(visited_children)
 
     def generic_visit(self, node, visited_children):
         return ''.join(visited_children) if visited_children else node.text

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -20,7 +20,7 @@ grammar = Grammar(
     rest = space? restHead space? rest*
     restHead = operatorsTop head
     heapPred = "emp" / (exp "::" exp "<" exp? ">@M")
-    boolExp = ("true" / "false" / alias / notAlias / boolPred / quantifierPred / boolCompare) (operatorsBool boolExp)*
+    boolExp = (("true" / "false" / alias / notAlias / boolPred / quantifierPred / boolCompare) (operatorsBool boolExp)*) / ("(" boolExp ")" (operatorsBool boolExp)*)
     alias = exp "=" exp
     notAlias = ("!(" exp "=" exp ")") / (exp "!=" exp)
     boolPred = exp "(" exp ")"

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -156,11 +156,12 @@ if __name__ == '__main__':
 
             # Step 2.
             # Repeat until fixpoint.
+            aliases = []
             formulaOld = formula
             while True:
                 tree = grammar.parse(formula)
                 ac = AliasCollector()
-                aliases = ac.visit(tree)
+                aliases = aliases + ac.visit(tree)
                 vr = VarReplacer(aliases)
                 formula = vr.visit(tree)
                 if formulaOld == formula:

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -152,7 +152,7 @@ if __name__ == '__main__':
                 raise Exception('Unhandled case')
 
             formula = ''.join(map(lambda x: x.strip(), formulaChunks))
-            formula = formula.split('&{FLOW,(20,21)=__norm#E}[]', 1)[0]
+            formula = formula.split('&{FLOW,(', 1)[0]
 
             # Step 2.
             # Repeat until fixpoint.

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -16,11 +16,11 @@ from parsimonious.exceptions import ParseError
 grammar = Grammar(
     r"""
     formula = space? head rest? space?
-    head = (heapPred / boolExp) / ("(" space? (heapPred / boolExp) space? ")")
+    head = (heapPred / alias / boolExp) / ("(" space? (heapPred / alias / boolExp) space? ")")
     rest = space? restHead space? rest*
     restHead = operatorsTop head
     heapPred = "emp" / (exp "::" exp "<" exp? ">@M")
-    boolExp = (("true" / "false" / alias / notAlias / boolPred / quantifierPred / boolCompare) (operatorsBool boolExp)*) / ("(" boolExp ")" (operatorsBool boolExp)*)
+    boolExp = (("true" / "false" / (exp "=" exp) / notAlias / boolPred / quantifierPred / boolCompare) (operatorsBool boolExp)*) / ("(" boolExp ")" (operatorsBool boolExp)*)
     alias = exp "=" exp
     notAlias = ("!(" exp "=" exp ")") / (exp "!=" exp)
     boolPred = exp "(" exp ")"

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -20,7 +20,7 @@ grammar = Grammar(
     rest = space? restHead space? rest*
     restHead = operatorsTop head
     heapPred = "emp" / (exp "::" exp "<" exp? ">@M")
-    boolExp = "true" / "false" / alias / notAlias / boolPred / boolCompare / quantifierPred
+    boolExp = ("true" / "false" / alias / notAlias / boolPred / quantifierPred / boolCompare) (operatorsBool boolExp)*
     alias = exp "=" exp
     notAlias = ("!(" exp "=" exp ")") / (exp "!=" exp)
     boolPred = exp "(" exp ")"
@@ -29,6 +29,7 @@ grammar = Grammar(
     exp = (var (operatorsExp exp)*) / (expEnclosed (operatorsExp exp)*)
     expEnclosed = "(" exp ")"
     operatorsTop = space? ("|-" / "*" / "&") space?
+    operatorsBool = space? ("|" / "&") space?
     operatorsCompare = space? ("<=" / ">=" / "<" / ">") space?
     operatorsExp = space? ("*" / "+" / "-") space?
     var = ~r"[a-zA-Z0-9_]+"

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -78,15 +78,11 @@ class AliasRemover(NodeVisitor):
     """Remove a trivial alias, and also remove the operator before (if available).
     """
 
-    def __init__(self):
-        self.isTrivialAliasHead = False
-
     def visit_head(self, node, visited_children):
         operand = node.children[0].children[0]
         if operand.expr_name == 'alias':
             alias, _, value = operand
             if alias.text == value.text:
-                self.isTrivialAliasHead = True
                 return ''
             else:
                 return ''.join(visited_children)
@@ -101,16 +97,8 @@ class AliasRemover(NodeVisitor):
                 if alias.text == value.text:
                     return ''
                 else:
-                    if self.isTrivialAliasHead:
-                        self.isTrivialAliasHead = False
-                        return ''.join(visited_children[1:])
-                    else:
-                        return ''.join(visited_children)
-        if self.isTrivialAliasHead:
-            self.isTrivialAliasHead = False
-            return ''.join(visited_children[1:])
-        else:
-            return ''.join(visited_children)
+                    return ''.join(visited_children)
+        return ''.join(visited_children)
 
     def generic_visit(self, node, visited_children):
         return ''.join(visited_children) if visited_children else node.text

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -19,7 +19,7 @@ grammar = Grammar(
     head = (heapPred / alias / boolExp) / ("(" space? (heapPred / alias / boolExp) space? ")")
     rest = space? restHead space? rest*
     restHead = operatorsTop head
-    heapPred = "emp" / (exp "::" exp "<" exp? ">@M")
+    heapPred = "emp" / "hfalse" / (exp "::" exp "<" exp? ">@M")
     boolExp = (("true" / "false" / (exp "=" exp) / notAlias / boolPred / quantifierPred / boolCompare) (operatorsBool boolExp)*) / ("(" boolExp ")" (operatorsBool boolExp)*)
     alias = exp "=" exp
     notAlias = ("!(" exp "=" exp ")") / (exp "!=" exp)

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -79,15 +79,13 @@ class AliasRemover(NodeVisitor):
     """
 
     def visit_head(self, node, visited_children):
-        operand = node.children[0]
-        if operand.expr_name == 'boolExp':
-            child = operand.children[0]
-            if child.expr_name == 'alias':
-                alias, _, value = child
-                if alias.text == value.text:
-                    return ''
-                else:
-                    return ''.join(visited_children)
+        operand = node.children[0].children[0]
+        if operand.expr_name == 'alias':
+            alias, _, value = operand
+            if alias.text == value.text:
+                return ''
+            else:
+                return ''.join(visited_children)
         return ''.join(visited_children)
 
     def visit_restHead(self, node, visited_children):

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -16,9 +16,9 @@ from parsimonious.exceptions import ParseError
 grammar = Grammar(
     r"""
     formula = space? head rest? space?
-    head = heapPred / boolExp
+    head = (heapPred / boolExp) / ("(" space? (heapPred / boolExp) space? ")")
     rest = space? restHead space? rest*
-    restHead = operatorsTop (heapPred / boolExp)
+    restHead = operatorsTop head
     heapPred = "emp" / (exp "::" exp "<" exp? ">@M")
     boolExp = "true" / "false" / alias / notAlias / boolPred / boolCompare / quantifierPred
     alias = exp "=" exp

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -26,8 +26,7 @@ grammar = Grammar(
     boolPred = exp "(" exp ")"
     boolCompare = exp operatorsCompare exp
     quantifierPred = exp "(" exp ":" formula ")"
-    exp = (var (operatorsExp exp)*) / (expEnclosed (operatorsExp exp)*)
-    expEnclosed = "(" exp ")"
+    exp = (var (operatorsExp exp)*) / ("(" exp ")" (operatorsExp exp)*)
     operatorsTop = space? ("|-" / "*" / "&") space?
     operatorsBool = space? ("|" / "&") space?
     operatorsCompare = space? ("<=" / ">=" / "<" / ">") space?

--- a/remove-aliases.py
+++ b/remove-aliases.py
@@ -22,7 +22,7 @@ grammar = Grammar(
     heapPred = "emp" / (exp "::" exp "<" exp? ">@M")
     boolExp = "true" / "false" / alias / notAlias / boolPred / boolCompare / quantifierPred
     alias = exp "=" exp
-    notAlias = "!(" exp "=" exp ")"
+    notAlias = ("!(" exp "=" exp ")") / (exp "!=" exp)
     boolPred = exp "(" exp ")"
     boolCompare = exp operatorsCompare exp
     quantifierPred = exp "(" exp ":" formula ")"


### PR DESCRIPTION
Expand grammar to handle quasiquoted formulas from invocations of `sleek -dre=isFailCtx` produced as a result of `pr_numbered_list_formula_trace_ho_inst`.

Fix `AliasRemover`.